### PR TITLE
feat: 병원 예약 결과 송출 페이지(승인/반려) 정적 구현

### DIFF
--- a/src/assets/translations/ko.json
+++ b/src/assets/translations/ko.json
@@ -158,11 +158,22 @@
         "wait": "잠시만 기다려주세요..."
         },
         "result": {
-            "message": "{메디메이트가 {name}님의\n사전 문진 작성을 완료했어요!",
+            "message": "메디메이트가 {name}님의\n사전 문진 작성을 완료했어요!",
             "messageParts": {
                 "part1": "메디메이트가 ",
                 "part2": " 님의\n사전 문진 작성을 완료했어요!"
         }
+        }
+    },
+
+    "call" :{
+        "loading": {
+            "message": "메디 메이트가\n {name}님의 사전 문진을 바탕으로\n 병원 진료를 예약중이에요.",
+            "messageParts" : {
+                "part1" :"메디 메이트가 \n",
+                "part2" :" 님의 사전 문진을 바탕으로\n병원 진료를 예약중이에요."
+                
+            }
         }
     },
 
@@ -183,9 +194,5 @@
             "diagnosisHistory": "진료 기록",
             "prescriptionHistory": "처방 기록"
         } 
-    },
-
-    "call" : {
-        
     }
 }

--- a/src/assets/translations/ko.json
+++ b/src/assets/translations/ko.json
@@ -17,7 +17,8 @@
         },
         "qrCode": "채팅방 QR",
         "call" : "병원 전화 예약",
-        "reservation_time": "예약 날짜 및 시간 선택"
+        "reservation_time": "예약 날짜 및 시간 선택",
+        "reservation_result": "병원 예약 확인"
     },
 
     "homepage": {
@@ -195,4 +196,6 @@
             "prescriptionHistory": "처방 기록"
         } 
     }
+
+    
 }

--- a/src/assets/translations/ko.json
+++ b/src/assets/translations/ko.json
@@ -16,7 +16,8 @@
             "description": "처방전 설명"
         },
         "qrCode": "채팅방 QR",
-        "call" : "병원 전화 예약"
+        "call" : "병원 전화 예약",
+        "reservation_time": "예약 날짜 및 시간 선택"
     },
 
     "homepage": {

--- a/src/components/commons/TopNavBar.jsx
+++ b/src/components/commons/TopNavBar.jsx
@@ -59,6 +59,9 @@ const NavBar = ({
                 leftIcon: LeftArrow,
                 rightIcon: Close,
             },
+            reservation_result: {
+                rightIcon: Close,
+            },
             default: {
                 leftIcon: LeftArrow,
                 rightIcon: Close,

--- a/src/pages/call-reservation-page/CallLoadingPage.jsx
+++ b/src/pages/call-reservation-page/CallLoadingPage.jsx
@@ -11,6 +11,10 @@ const CallLoadingPage = () => {
     const { t, i18n } = useTranslation();
     const { user } = useUser();
     const language = i18n.language;
+    
+    // 전달받은 예약 정보
+    const reservationInfo = location.state || {};
+    const { userName, selectedDate, selectedTime } = reservationInfo;
 
 
 

--- a/src/pages/call-reservation-page/CallLoadingPage.jsx
+++ b/src/pages/call-reservation-page/CallLoadingPage.jsx
@@ -1,0 +1,35 @@
+import { useLocation, useNavigate } from "react-router-dom";
+import { useTranslation } from "react-i18next";
+import { useEffect } from "react";
+import { useUser } from "@contexts/UserContext";
+
+import Loading from "@assets/images/loading.svg";
+
+const CallLoadingPage = () => {
+    const location = useLocation();
+    const navigate = useNavigate();
+    const { t, i18n } = useTranslation();
+    const { user } = useUser();
+    const language = i18n.language;
+
+
+
+    return (
+        <div className="flex flex-col items-center px-5 mt-25">
+            <div className="text-center">
+                <p className="text-xl font-semibold whitespace-pre-line">
+                    {t('call.loading.messageParts.part1')}
+                    {user && <span className="text-[#3DE0AB] font-semibold">{user.name}</span>}
+                    {t('call.loading.messageParts.part2')}
+                </p>
+                
+                <img src={Loading} className="animate-spin fixed left-1/2 top-1/2 transform -translate-x-1/2 -translate-y-1/2"/>
+                <p className="text-[#A6A9AA] font-semibold fixed left-1/2 top-1/2 transform -translate-x-1/2 -translate-y-1/2 mt-18">
+                    {t('prescription.scanning.wait')}
+                </p>
+            </div>
+        </div>
+    );
+};
+
+export default CallLoadingPage;

--- a/src/pages/call-reservation-page/CallResultApprovePage.jsx
+++ b/src/pages/call-reservation-page/CallResultApprovePage.jsx
@@ -1,0 +1,49 @@
+import { useLocation, useNavigate } from "react-router-dom";
+import { useTranslation } from "react-i18next";
+import { useEffect } from "react";
+import { useUser } from "@contexts/UserContext";
+import TextButton from "@components/commons/TextButton";
+import WhiteChevronRight from "@assets/images/white_chevron_right.svg";
+
+
+const CallResultApprovePage = () => {
+    const location = useLocation();
+    const navigate = useNavigate();
+    const { t, i18n } = useTranslation();
+    const language = i18n.language;
+    const { user } = useUser();
+
+    const handleNext = () => {
+            navigate('/home');
+        
+    };
+
+
+    return (
+        <div className="mt-15">
+            <div className="flex items-center text-[20px] text-black font-medium leading-relaxed ml-15">
+                {user?.name}님의 예약이 
+                <span className="text-[#3DE0AB] pl-1"> 승인</span>
+                되었습니다.
+            </div>
+            <div className="flex flex-col item-left mt-20 ml-5 font-medium ">
+                <div className="text-[20px] text-gray-400 leading-relaxed">
+                    예약 날짜
+                </div>
+                <div className="text-[24px] text-black leading-relaxed">2025-08-25</div>
+                <div className="mt-8 text-[20px] text-gray-400 leading-relaxed">
+                    예약 시간
+                </div>
+                <div className="text-[24px] text-black leading-relaxed">14:00</div>
+            </div>
+
+            <TextButton
+                text="예약 내역 확인하기"
+                onClick={handleNext}
+                icon={WhiteChevronRight}
+            />
+        </div>
+    );
+};
+
+export default CallResultApprovePage;

--- a/src/pages/call-reservation-page/CallResultDeniedPage.jsx
+++ b/src/pages/call-reservation-page/CallResultDeniedPage.jsx
@@ -1,0 +1,41 @@
+import { useLocation, useNavigate } from "react-router-dom";
+import { useTranslation } from "react-i18next";
+import { useEffect } from "react";
+import { useUser } from "@contexts/UserContext";
+import TextButton from "@components/commons/TextButton";
+import GreenChevronRight from "@assets/images/green_chevron_right.svg";
+
+
+const CallResultDeniedPage = () => {
+    const location = useLocation();
+    const navigate = useNavigate();
+    const { t, i18n } = useTranslation();
+    const language = i18n.language;
+    const { user } = useUser();
+
+    const handleNext = () => {
+            navigate('/home');
+        
+    };
+
+
+    return (
+        <div className="mt-15">
+            <div className="flex items-center text-[20px] text-black font-medium leading-relaxed ml-15">
+                {user?.name}님의 병원 예약이 
+                <span className="text-[#3DE0AB] pl-1"> 반려</span>
+                되었어요.
+            </div>
+        
+
+            <TextButton
+                text="홈으로 가기"
+                onClick={handleNext}
+                icon={GreenChevronRight}
+                className ="bg-[#9DEECF] !text-[#00A270]"
+            />
+        </div>
+    );
+};
+
+export default CallResultDeniedPage;

--- a/src/pages/call-reservation-page/CallTimePage.jsx
+++ b/src/pages/call-reservation-page/CallTimePage.jsx
@@ -1,8 +1,9 @@
 /* 병원 예약 희망 시간 기재 */
 
-//import { useTranslation } from "react-i18next";
+import { useTranslation } from "react-i18next";
 import { useState, useRef, useEffect } from "react";
 import { useNavigate } from "react-router";
+import { useUser } from "@contexts/UserContext";
 import TextButton from "../../components/commons/TextButton";
 import TextField from "../../components/forms/TextField";
 import TitleBlock from "../../components/commons/TitleBlock";
@@ -12,7 +13,8 @@ import Clock from "@assets/images/clock.svg";
 
 
 const CallTimePage = () => {
-    
+    const { t } = useTranslation();
+    const { user } = useUser();
     const [selectedDate, setSelectedDate] = useState('');
     const [selectedTime, setSelectedTime] = useState('');
     const [showTimePicker, setShowTimePicker] = useState(false);
@@ -61,7 +63,14 @@ const CallTimePage = () => {
 
 
     const handleNext = () => {
-        navigate('/treat-info-form/country')
+        // 선택된 날짜와 시간을 CallLoadingPage로 전달
+        navigate('/call-loading', {
+            state: {
+                userName: user?.name,
+                selectedDate: selectedDate,
+                selectedTime: selectedTime
+            }
+        });
     };
 
     

--- a/src/routes/Router.jsx
+++ b/src/routes/Router.jsx
@@ -25,6 +25,7 @@ import TreantInfoScanningPage from '@/pages/treat-info-form/TreantInfoScanningPa
 import TreantInfoResultPage from '@/pages/treat-info-form/TreatInfoResultPage';
 import CallNumberPage from '@/pages/call-reservation-page/CallNumberPage';
 import CallTimePage from '@/pages/call-reservation-page/CallTimePage';
+import CallLoadingPage from '@/pages/call-reservation-page/CallLoadingPage';
 
 const Router = () => {
     return (
@@ -60,6 +61,7 @@ const Router = () => {
                         
                         <Route path="prescription/scanning" element={<PrescriptionScanningPage />} />
                         <Route path="treat-info/scanning" element={<TreantInfoScanningPage />} />
+                        <Route path="call-reservation/loading" element={<CallLoadingPage/>} />
                     </Routes>
                     </TreatInfoProvider>
                 </UserProvider>

--- a/src/routes/Router.jsx
+++ b/src/routes/Router.jsx
@@ -26,6 +26,7 @@ import TreantInfoResultPage from '@/pages/treat-info-form/TreatInfoResultPage';
 import CallNumberPage from '@/pages/call-reservation-page/CallNumberPage';
 import CallTimePage from '@/pages/call-reservation-page/CallTimePage';
 import CallLoadingPage from '@/pages/call-reservation-page/CallLoadingPage';
+import CallResultApprovePage from '@/pages/call-reservation-page/CallResultApprovePage';
 
 const Router = () => {
     return (
@@ -57,6 +58,7 @@ const Router = () => {
                             <Route path="prescription/result" element={<PrescriptionResultPage />} />
                             <Route path='call-reservation/number' element={<CallNumberPage/>}/>
                             <Route path='call-reservation/time' element={<CallTimePage/>}/>
+                            <Route path='call-reservation/result/approved' element={<CallResultApprovePage/>}/>
                         </Route>
                         
                         <Route path="prescription/scanning" element={<PrescriptionScanningPage />} />

--- a/src/routes/Router.jsx
+++ b/src/routes/Router.jsx
@@ -27,6 +27,7 @@ import CallNumberPage from '@/pages/call-reservation-page/CallNumberPage';
 import CallTimePage from '@/pages/call-reservation-page/CallTimePage';
 import CallLoadingPage from '@/pages/call-reservation-page/CallLoadingPage';
 import CallResultApprovePage from '@/pages/call-reservation-page/CallResultApprovePage';
+import CallResultDeniedPage from '@/pages/call-reservation-page/CallResultDeniedPage';
 
 const Router = () => {
     return (
@@ -59,6 +60,7 @@ const Router = () => {
                             <Route path='call-reservation/number' element={<CallNumberPage/>}/>
                             <Route path='call-reservation/time' element={<CallTimePage/>}/>
                             <Route path='call-reservation/result/approved' element={<CallResultApprovePage/>}/>
+                            <Route path='call-reservation/result/denied' element={<CallResultDeniedPage/>}/>
                         </Route>
                         
                         <Route path="prescription/scanning" element={<PrescriptionScanningPage />} />

--- a/src/utils/navConfig.js
+++ b/src/utils/navConfig.js
@@ -11,7 +11,8 @@ const getNavBarType = (pathname) => {
     if (pathname === '/prescription/result') return 'prescription_result';
     if (pathname === ('/treat-info/result')) return 'precheck';
     if (pathname === '/mypage/history') return 'history';
-    if (pathname.startsWith ('/call-reservation')) return 'call';
+    if (pathname ===  '/call-reservation/number') return 'call';
+    if (pathname === '/call-reservation/time') return'reservation_time'
     if (pathname.endsWith('/qr')) return 'qr';
     if (pathname.startsWith('/chat/')) return 'chatroom';
     if (pathname.startsWith('/treat-info-form')) return 'treat-info-form'; 
@@ -42,7 +43,9 @@ const getNavBarTitle = (type, t) => {
         case 'qr':
             return t('navigation.qrCode');
         case 'call':
-            return t('navigation.call')
+            return t('navigation.call');
+        case 'reservation_time':
+            return t('navigation.reservation_time');
         case 'home':
         case 'chat':
         case 'chatroom':
@@ -103,6 +106,7 @@ const getNavBarHandlers = (type, navigate, toggleSearchMode = null) => {
         case 'prescription':
         case 'prescription_upload':
         case 'history':
+        case 'reservation_time':
         case 'default':
         default:
             return {

--- a/src/utils/navConfig.js
+++ b/src/utils/navConfig.js
@@ -12,7 +12,8 @@ const getNavBarType = (pathname) => {
     if (pathname === ('/treat-info/result')) return 'precheck';
     if (pathname === '/mypage/history') return 'history';
     if (pathname ===  '/call-reservation/number') return 'call';
-    if (pathname === '/call-reservation/time') return'reservation_time'
+    if (pathname === '/call-reservation/time') return'reservation_time';
+    if (pathname.startsWith ('/call-reservation/result')) return 'reservation_result';
     if (pathname.endsWith('/qr')) return 'qr';
     if (pathname.startsWith('/chat/')) return 'chatroom';
     if (pathname.startsWith('/treat-info-form')) return 'treat-info-form'; 
@@ -46,6 +47,8 @@ const getNavBarTitle = (type, t) => {
             return t('navigation.call');
         case 'reservation_time':
             return t('navigation.reservation_time');
+        case 'reservation_result':
+            return t('navigation.reservation_result');
         case 'home':
         case 'chat':
         case 'chatroom':
@@ -99,6 +102,10 @@ const getNavBarHandlers = (type, navigate, toggleSearchMode = null) => {
             };
         case 'prescription_result':
         case 'precheck':
+            return {
+                onRightClick: () => navigate('/home')
+            };
+        case 'reservation_result' :
             return {
                 onRightClick: () => navigate('/home')
             };


### PR DESCRIPTION
## 구현 내용
- 병원 예약 결과 승인 페이지 (정적)
- 병원 예약 결과 반려 페이지 (정적)
- user.name (동적)

## 논의 사항
- 만약, user가 가족(자녀 등)의 병원 방문을 대신 예약해준다면 username을 어떻게 표시해야하나요?
- 현재는 로그인 기능이 없어 해당 부분 해결이 어려워 보임