### PR TITLE
Feat: 채팅방 타입 고정에 따른 로직 및 디자인 변경

### DIFF
--- a/src/assets/translations/en.json
+++ b/src/assets/translations/en.json
@@ -153,6 +153,7 @@
         "selectChatType": "Please click the chat room button.",
         "enterMessage": "Enter message",
         "type": {
+            "chat": "Chat",
             "newChat": "New Chat",
             "precheck": "Consultation",
             "prescription": "Prescription"

--- a/src/assets/translations/ko.json
+++ b/src/assets/translations/ko.json
@@ -155,6 +155,7 @@
         "selectChatType": "채팅방의 버튼을 클릭해주세요.",
         "enterMessage": "채팅을 입력해주세요...",
         "type": {
+            "chat": "채팅",
             "newChat": "신규",
             "precheck": "진료",
             "prescription": "처방"

--- a/src/assets/translations/zh-CN.json
+++ b/src/assets/translations/zh-CN.json
@@ -153,6 +153,7 @@
         "selectChatType": "请点击聊天室按钮。",
         "enterMessage": "请输入消息...",
         "type": {
+            "chat": "聊天",
             "newChat": "新聊天",
             "precheck": "诊疗",
             "prescription": "处方"

--- a/src/pages/chat-page/ChatPage.jsx
+++ b/src/pages/chat-page/ChatPage.jsx
@@ -95,9 +95,8 @@ const ChatPage = () => {
                         <div key={room.id} className="m-0">
                             <ServiceCard 
                                 icon={Logo}
-                                title={room.roomCode}
+                                title={room.createdAt}
                                 description={room.lastChat}
-                                description2={room.createdAt}
                                 onClick={() => handleChatRoomClick(room.id, room.roomCode)}
                                 className="shadow-none"
                             />

--- a/src/pages/chat-page/ChatRoomPage.jsx
+++ b/src/pages/chat-page/ChatRoomPage.jsx
@@ -289,7 +289,7 @@ const ChatRoomPage = () => {
                     />
                 ) : (
                     <p className="p-2.5 pt-4.5 font-semibold">
-                        {roomInfo && `${t(`chat.type.${roomInfo.type}`)} | ${roomInfo.date}`}
+                        {roomInfo && `${t("chat.type.chat")} | ${roomInfo.date}`}
                     </p>
                 )}
                 <div className="h-[1px] w-[335px] bg-[#E0E0E0]"/>
@@ -311,7 +311,7 @@ const ChatRoomPage = () => {
                             ref={(el) => messageRefs.current[message.id] = el}
                         />
                         {/* 첫 번째 메시지 아래에 버튼들 렌더링 */}
-                        {index === 0 && roomInfo && roomInfo.type === "newChat" && !hasUserSentMessage && (
+                        {index === 0 && message.sender == "medi" && !hasUserSentMessage && (
                             <div className="pl-13.75 py-2 mb-4 flex flex-col items-start gap-2">
                                 {initBtnList.map((btn, btnIndex) => (
                                     <TextButton 


### PR DESCRIPTION
## 📝메인 작업 내용
 - 채팅방 타입 '채팅' 고정에 따른 채팅방 페이지에서 해당 타입만 띄워주게 됨
 - 버튼이 뜨는 조건을 메세지 1개 && 첫번째 메세지 sender가 medi인 경우로 개편
 - 채팅방 리스트에서 타이틀을 채팅방 생성 날짜로 변경
 
## 🖼 개편 UI 사진
<img width="366" height="84" alt="image" src="https://github.com/user-attachments/assets/7d862f1e-6656-48ef-bdfe-394a74d82e4c" />
