### PR TITLE
Feat: 연동을 위한 deploy.yml 추가

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,34 @@
+name: Deploy
+
+on:
+  push:
+    branches: ['master'] # 어떤 브랜치에 push 될 때 실행할건지
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    container: pandoc/latex
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Install mustache (to update the date)
+        run: apk add ruby && gem install mustache
+
+      - name: creates output
+        run: sh ./build.sh
+
+      - name: Pushes to another repository
+        id: push_directory
+        uses: cpina/github-action-push-to-another-repository@main
+        env:
+          API_TOKEN_GITHUB: ${{ secrets.AUTO_ACTIONS }} # 5번에서 설정한 secret 토큰 중 ghp_ 로 시작하는 값 넣은 변수
+        with:
+          source-directory: 'output'
+          destination-github-username: MNA11 # 개인 레포 소유자의 username
+          destination-repository-name: team1-fe # 포크 뜬 개인 레포 이름
+          user-email: ${{ secrets.OFFICIAL_ACCOUNT_EMAIL }} # 개인 계정 이메일
+          commit-message: ${{ github.event.commits[0].message }}
+          target-branch: master # 개인 레포의 어느 브랜치에 복사할건지
+
+      - name: Test get variable exported by push-to-another-repository
+        run: echo $DESTINATION_CLONED_DIRECTORY


### PR DESCRIPTION
## 작업 내용
- GitHub Actions 설정하기 위해, deploy.yml 생성
```
name: Deploy

on:
  push:
    branches: ['master'] # 어떤 브랜치에 push 될 때 실행할건지

jobs:
  build:
    runs-on: ubuntu-latest
    container: pandoc/latex
    steps:
      - uses: actions/checkout@v2

      - name: Install mustache (to update the date)
        run: apk add ruby && gem install mustache

      - name: creates output
        run: sh ./build.sh

      - name: Pushes to another repository
        id: push_directory
        uses: cpina/github-action-push-to-another-repository@main
        env:
          API_TOKEN_GITHUB: ${{ secrets.AUTO_ACTIONS }} # 5번에서 설정한 secret 토큰 중 ghp_ 로 시작하는 값 넣은 변수
        with:
          source-directory: 'output'
          destination-github-username: MNA11 # 개인 레포 소유자의 username
          destination-repository-name: team1-fe # 포크 뜬 개인 레포 이름
          user-email: ${{ secrets.OFFICIAL_ACCOUNT_EMAIL }} # 개인 계정 이메일
          commit-message: ${{ github.event.commits[0].message }}
          target-branch: master # 개인 레포의 어느 브랜치에 복사할건지

      - name: Test get variable exported by push-to-another-repository
        run: echo $DESTINATION_CLONED_DIRECTORY
```