### PR TITLE
Fix: LeftIcon 존재 유무 명시 및 렌더링 분기

### DIFF
--- a/src/components/commons/NavBar.jsx
+++ b/src/components/commons/NavBar.jsx
@@ -66,6 +66,7 @@ const NavBar = ({
                 rightIcon: Close
             },
             precheck: {
+                leftIcon: null,
                 rightIcon:Close,
             },
             call: {
@@ -73,6 +74,7 @@ const NavBar = ({
                 rightIcon: Close,
             },
             reservation_result: {
+                leftIcon: null,
                 rightIcon: Close,
             },
             language: {
@@ -93,12 +95,12 @@ const NavBar = ({
     return (
         <div className={baseClasses}>
             <div className="flex-1 flex justify-start items-center">
-                <img 
+                {config.leftIcon && <img 
                     className={`${disableLeftClick ? 'opacity-50 cursor-not-allowed' : 'hover:cursor-pointer'}`} 
                     src={config.leftIcon} 
                     alt="navbar_left_icon"
                     onClick={disableLeftClick ? undefined : onLeftClick}
-                />
+                />}
             </div>
             <div className="flex-2 flex justify-center items-center">
                 <p className="font-semibold text-5">{title}</p>


### PR DESCRIPTION
## 📑 메인 작업 내용
- 이슈: alt 작성 -> 기존 null로 넘어가던 leftIcon의 alt가 대체로 보임으로 UI 깨짐 현상 발생
- NavBar에서 LeftIcon 존재 유무 명시 및 렌더링 분기 