### PR TITLE
Fix: 잘못된 번역 키값 사용 수정

### DIFF
--- a/src/pages/treat-info-form/TreatInfoScanningPage.jsx
+++ b/src/pages/treat-info-form/TreatInfoScanningPage.jsx
@@ -49,7 +49,7 @@ const TreantInfoScanningPage = () => {
                 
                 <img src={Loading} alt="loading" className="animate-spin fixed left-1/2 top-1/2 transform -translate-x-1/2 -translate-y-1/2"/>
                 <p className="max-w-[375px] text-[#A6A9AA] font-semibold fixed left-1/2 top-1/2 transform -translate-x-1/2 -translate-y-1/2 mt-18">
-                    {t('prescription.scanning.wait')}
+                    {t('precheck.scanning.wait')}
                 </p>
             </div>
         </div>


### PR DESCRIPTION
## 📑 메인 작업 내용
- precheck loading에서 prescription.scanning.wait 키값을 쓰던 것을 precheck.scanning.wait으로 변경