### PR TITLE
Fix: 이동 버튼에 번역 버튼이 가려지는 문제 해결

### DIFF
--- a/src/pages/treat-info-form/TreatInfoResultPage.jsx
+++ b/src/pages/treat-info-form/TreatInfoResultPage.jsx
@@ -92,7 +92,7 @@ const TreantInfoResultPage = () => {
                     className="flex justify-center items-center 
                                 font-medium rounded-sm
                                 bg-[#3DE0AB] text-white text-sm
-                                w-full h-[32px] mt-6 cursor-pointer"
+                                w-full h-[32px] mt-6 cursor-pointer mb-40"
                 >
                     {t('precheck.buttons.translate')}
                 </button>


### PR DESCRIPTION
## 📑 메인 작업 내용
- 이동 버튼에 번역 버튼이 가려지는 문제 해결